### PR TITLE
Feat: #5 - 도메인 구현 및 데이터베이스 연결

### DIFF
--- a/src/main/java/com/fescaro/interview/InterviewApplication.java
+++ b/src/main/java/com/fescaro/interview/InterviewApplication.java
@@ -2,8 +2,10 @@ package com.fescaro.interview;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class InterviewApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/fescaro/interview/dto/FileDto.java
+++ b/src/main/java/com/fescaro/interview/dto/FileDto.java
@@ -1,0 +1,34 @@
+package com.fescaro.interview.dto;
+
+import com.fescaro.interview.entity.FileEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+public class FileDto {
+    private Long id;
+    private String originFileName;
+    private String originFilePath;
+    private String encryptedFileName;
+    private String encryptedFilePath;
+    private String iv;
+    private LocalDateTime createdAt;
+
+    public static FileDto from(FileEntity entity) {
+        return FileDto.builder()
+                .id(entity.getId())
+                .originFileName(entity.getOriginFileName())
+                .originFilePath(entity.getOriginFilePath())
+                .encryptedFileName(entity.getEncryptedFileName())
+                .encryptedFilePath(entity.getEncryptedFilePath())
+                .iv(entity.getIv())
+//                .ivBytes(entity.getIvBytes())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/fescaro/interview/entity/AuditingFields.java
+++ b/src/main/java/com/fescaro/interview/entity/AuditingFields.java
@@ -1,0 +1,22 @@
+package com.fescaro.interview.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 일시
+}

--- a/src/main/java/com/fescaro/interview/entity/FileEntity.java
+++ b/src/main/java/com/fescaro/interview/entity/FileEntity.java
@@ -1,0 +1,35 @@
+package com.fescaro.interview.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Table(name = "file_entity")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FileEntity extends AuditingFields {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "origin_file_name", unique = true)
+    private String originFileName;
+
+    @Column(name = "origin_file_path", unique = true)
+    private String originFilePath;
+
+    @Column(name = "encrypted_file_name", unique = true)
+    private String encryptedFileName;
+
+    @Column(name = "encrypted_file_path", unique = true)
+    private String encryptedFilePath;
+
+    @Column(name = "iv")
+    private String iv;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,16 @@
 
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/fescaro
+    username: root
+    password: 1234
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+    open-in-view: false


### PR DESCRIPTION
프로젝트 진행에 필요한 도메인을 구현하고, 데이터베이스를 연결하였다.

테이블의 경우, 암호화 대상 파일과 암호화 된 파일을 별도의 테이블로 다루는 것을 고려하였지만
다운로드 기능 이외에는 두 파일이 함께 조회되어야 하는 경우가 많을 것으로 예상되기 때문에
하나의 테이블에 관리하도록 하였다.

This closes #5 